### PR TITLE
Testing farm request options in wrong format

### DIFF
--- a/tasks/testing-farm.yaml
+++ b/tasks/testing-farm.yaml
@@ -72,8 +72,8 @@ spec:
           --compose "${COMPOSE}" \
           --arch "${ARCH}" \
           --timeout "${TIMEOUT}" \
-          --hardware "memory='>= 16 GB'" \
-          --hardware "virtualization.is-supported='true'" \
-          --hardware "disk.size='>= 80 GB'" \
-          --hardware "cpu.processors='>= 4'" \
+          --hardware memory='>= 16 GB' \
+          --hardware virtualization.is-supported='true' \
+          --hardware disk.size='>= 80 GB' \
+          --hardware cpu.processors='>= 4' \
           --environment INDEX_OCP_VER="$(echo ${INDEX_OCP_VER})" 


### PR DESCRIPTION
In TF request options relates to hardware
are in wrong format. Fix format.