### PR TITLE
Add --verbose flag to all operator-sdk commands

### DIFF
--- a/Setup/setup_local_cluster/runtest.sh
+++ b/Setup/setup_local_cluster/runtest.sh
@@ -53,7 +53,7 @@ rlJournalStart
             rlRun "echo 'OLM as already installed.'"
           else
             rlRun "echo 'Instaling OLM'"
-            rlRun "operator-sdk --timeout ${OLM_INSTALL_TIMEOUT} olm install"
+            rlRun "operator-sdk --verbose --timeout ${OLM_INSTALL_TIMEOUT} olm install"
           fi
           #not use function script due possible usage of this setup for other components
           rlRun "minikube status"

--- a/ocpop-lib/lib.sh
+++ b/ocpop-lib/lib.sh
@@ -1575,7 +1575,7 @@ ocpopBundleStart() {
     then
       rlRun "operator-sdk --verbose run bundle --timeout ${TO_BUNDLE} ${BUNDLE_IMAGE_USED} ${RUN_BUNDLE_PARAMS} --namespace ${OPERATOR_NAMESPACE}"
     else
-      rlRun "operator-sdk run bundle --timeout ${TO_BUNDLE} ${BUNDLE_IMAGE_USED} ${RUN_BUNDLE_PARAMS} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null"
+      rlRun "operator-sdk --verbose run bundle --timeout ${TO_BUNDLE} ${BUNDLE_IMAGE_USED} ${RUN_BUNDLE_PARAMS} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null"
     fi
     return $?
 }
@@ -1701,7 +1701,7 @@ ocpopBundleInitialStop() {
     then
         operator-sdk --verbose cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE}
     else
-        operator-sdk cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null
+        operator-sdk --verbose cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null
     fi
     if [ $? -eq 0 ];
     then
@@ -1741,9 +1741,9 @@ ocpopBundleStop() {
     fi
     if [ "${V}" == "1" ] || [ "${VERBOSE}" == "1" ];
     then
-        operator-sdk cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE}
+        operator-sdk --verbose cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE}
     else
-        operator-sdk cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null
+        operator-sdk --verbose cleanup ${OPERATOR_NAME} --namespace ${OPERATOR_NAMESPACE} 2>/dev/null
     fi
     if [ $? -eq 0 ];
     then


### PR DESCRIPTION
Enable verbose logging for all operator-sdk invocations to improve troubleshooting and debugging capabilities. This ensures consistent logging behavior across all operations (run bundle, cleanup, olm install).

## Summary by Sourcery

Add the --verbose flag to all operator-sdk commands to enable detailed logging and consistent troubleshooting output

Enhancements:
- Enable verbose logging for operator-sdk run bundle and cleanup commands in ocpop-lib/lib.sh
- Enable verbose logging for operator-sdk olm install in setup_local_cluster/runtest.sh