### PR TITLE
Increase Sanity timeouts (10m->15m)

### DIFF
--- a/Setup/install_setup_oc/main.fmf
+++ b/Setup/install_setup_oc/main.fmf
@@ -5,6 +5,6 @@ contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 recommend:
   - curl
-duration: 10m
+duration: 15m
 enabled: true
 id: b1f5d79c-9550-408d-99d7-c28ee93266bc

--- a/Setup/install_setup_operator-sdk/main.fmf
+++ b/Setup/install_setup_operator-sdk/main.fmf
@@ -5,6 +5,6 @@ contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 recommend:
   - curl
-duration: 10m
+duration: 15m
 enabled: true
 id: d8b2966a-2406-4e48-b673-005ba5fd6633

--- a/Setup/install_upstream_operator/main.fmf
+++ b/Setup/install_upstream_operator/main.fmf
@@ -7,6 +7,6 @@ require:
   - podman
   - go
   - git
-duration: 10m
+duration: 15m
 enabled: true
 id: 70b0d412-1d15-44b3-80db-7300351ce919

--- a/Setup/setup_local_cluster/main.fmf
+++ b/Setup/setup_local_cluster/main.fmf
@@ -7,6 +7,6 @@ require:
   - libvirt-daemon
   - podman
   - curl
-duration: 10m
+duration: 15m
 enabled: true
 id: 5227fefe-474e-4f82-b61e-bb5d50190a03


### PR DESCRIPTION
## Summary by Sourcery

Increase the default timeout for sanity checks across various FMF setup modules from 10 minutes to 15 minutes

Enhancements:
- Bump timeout values in install_setup_oc, install_setup_operator-sdk, install_upstream_operator, and setup_local_cluster FMF modules

Tests:
- Extend sanity test durations from 10m to 15m