### PR TITLE
Fix empty service IP when ELB DNS resolution fails

### DIFF
--- a/ocpop-lib/lib.sh
+++ b/ocpop-lib/lib.sh
@@ -810,6 +810,11 @@ ocpopGetServiceIp() {
                 # Resolve hostname to IP (first A record)
                 service_ip=$(getent ahostsv4 "${raw_ingress}" | awk '{print $1; exit}')
                 ocpopLogVerbose "Resolved HOSTNAME:[${raw_ingress}] to IP:[${service_ip}]"
+                # If resolution fails, use hostname directly (curl can resolve it)
+                if [ -z "${service_ip}" ]; then
+                    service_ip="${raw_ingress}"
+                    ocpopLogVerbose "Using HOSTNAME directly:[${service_ip}]"
+                fi
             fi
         fi
 


### PR DESCRIPTION
On AWS, LoadBalancer services get an ELB hostname instead of a direct IP. The ocpopGetServiceIp function attempted to resolve this hostname to an IP using getent ahostsv4, but when DNS resolution failed (e.g. due to propagation delay), the function returned no output after exhausting all iterations.

This caused service_ip to be empty, leading to argument shifting in unquoted calls like ocpopCheckServiceUp, producing malformed URLs such as "http://7500:nbde/adv" instead of "http://<host>:7500/adv".

Fix by falling back to the hostname directly when getent resolution fails. curl and other HTTP tools can resolve hostnames on their own, so pre-resolution to an IP is not required.

## Summary by Sourcery

Bug Fixes:
- Prevent empty service_ip values by falling back to the original hostname when ELB DNS resolution fails in ocpopGetServiceIp.