### PR TITLE
Use unresolved hostname as fallback in ocpopGetServiceIp

### DIFF
--- a/ocpop-lib/lib.sh
+++ b/ocpop-lib/lib.sh
@@ -810,11 +810,6 @@ ocpopGetServiceIp() {
                 # Resolve hostname to IP (first A record)
                 service_ip=$(getent ahostsv4 "${raw_ingress}" | awk '{print $1; exit}')
                 ocpopLogVerbose "Resolved HOSTNAME:[${raw_ingress}] to IP:[${service_ip}]"
-                # If resolution fails, use hostname directly (curl can resolve it)
-                if [ -z "${service_ip}" ]; then
-                    service_ip="${raw_ingress}"
-                    ocpopLogVerbose "Using HOSTNAME directly:[${service_ip}]"
-                fi
             fi
         fi
 
@@ -830,6 +825,14 @@ ocpopGetServiceIp() {
         counter=$((counter+1))
         sleep 1
     done
+
+    # If we exhausted iterations but have a hostname, use it directly
+    # (curl and other tools can resolve hostnames on their own)
+    if [[ -n "${raw_ingress}" && "${raw_ingress}" != "<pending>" ]]; then
+        ocpopLogVerbose "Using unresolved HOSTNAME directly:[${raw_ingress}]"
+        echo "${raw_ingress}"
+        return 0
+    fi
 
     return 1
 }


### PR DESCRIPTION
Commit description:
On AWS, LoadBalancer services receive an ELB hostname instead of a direct IP. ocpopGetServiceIp tries to resolve this hostname to an IP using getent ahostsv4, but when DNS propagation is slow, the resolution may never succeed within the retry window.

Previously, the function returned nothing (empty string) after exhausting all iterations. This caused argument shifting in callers that use the result unquoted, producing malformed URLs like "http://7500:nbde/adv" instead of "http://<host>:7500/adv".

After all iterations are exhausted, fall back to returning the hostname directly. curl and other HTTP tools can resolve hostnames on their own, so this prevents the empty-string bug while preserving the full DNS resolution wait time.

## Summary by Sourcery

Bug Fixes:
- Prevent empty-string return from ocpopGetServiceIp when DNS resolution of a LoadBalancer hostname does not succeed within the retry window, avoiding malformed URLs in callers.