### PR TITLE
Add '--skip-summary' option

### DIFF
--- a/pipelines/ephemeral-cluster-tf.yaml
+++ b/pipelines/ephemeral-cluster-tf.yaml
@@ -199,6 +199,7 @@ spec:
                 --compose "'${COMPOSE}'" \
                 --arch "'${ARCH}'" \
                 --timeout "'${TIMEOUT}'" \
+                --skip-summary \
                 --context distro="'${DISTRO}'"'
               # Print the constructed command for debugging purposes
               echo "Executing command: $REQUEST_CMD "


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Pass a --skip-summary option to the ephemeral cluster Terraform invocation to suppress summary output during pipeline execution.